### PR TITLE
Snapshots nail driver at 0720a.

### DIFF
--- a/src/ODEPlugin/NailDriver.cpp
+++ b/src/ODEPlugin/NailDriver.cpp
@@ -96,10 +96,12 @@ Device* NailDriver::clone() const
  */
 NailDriver::NailDriver()
 {
-    on_ = true;
+    on_ = false;
     position << 0, 0, 0;
     normalLine << 0, 0, 0;
     maxFasteningForce = std::numeric_limits<double>::max();
+
+    resetLatestContact();
 }
 
 void NailDriver::copyStateFrom(const NailDriver& other)
@@ -135,6 +137,11 @@ double* NailDriver::writeState(double* out_buf) const
 void NailDriver::on(bool on) {
     MessageView::instance()->putln(boost::format(_("*** %s: %s ***")) % typeName() % (on ? "ON" : "OFF"));
     cout << boost::format(_("*** %s: %s ***")) % typeName() % (on ? "ON" : "OFF") << endl;
+    if (on_ == false && on == true) {
+        // By switching from off to on,
+        // it becomes possible to injection of a nail.
+        resetLatestContact();
+    }
     on_ = on;
 }
 

--- a/src/ODEPlugin/NailDriver.h
+++ b/src/ODEPlugin/NailDriver.h
@@ -40,6 +40,10 @@ public:
 
     int checkContact(int numContacts, dContact* contacts);
 
+    void setLatestContact(const double current) { latestContact = current; }
+    double getLatestContact() { return latestContact; }
+    void resetLatestContact() { latestContact = 0.0; }
+
 private:
     bool on_;
 
@@ -47,6 +51,7 @@ public:
     Vector3 position;
     Vector3 normalLine;
     double maxFasteningForce;
+    double latestContact;
 };
 
 typedef ref_ptr<NailDriver> NailDriverPtr;

--- a/src/ODEPlugin/NailedObjectManager.cpp
+++ b/src/ODEPlugin/NailedObjectManager.cpp
@@ -73,7 +73,12 @@ bool NailedObjectManager::find(dBodyID bodyID)
 
 NailedObjectPtr NailedObjectManager::get(dBodyID bodyID)
 {
-    return objectMap[bodyID];
+    NailedObjectMap::iterator p = objectMap.find(bodyID);
+    if (p != objectMap.end()){
+        return p->second;
+    }
+
+    return 0;
 }
 
 

--- a/src/ODEPlugin/NailedObjectManager.h
+++ b/src/ODEPlugin/NailedObjectManager.h
@@ -23,6 +23,7 @@ class CNOID_EXPORT NailedObject : public Referenced
 {
 public:
     NailedObject(dBodyID objID) {
+        nailCount = 0;
         maxFasteningForce = 0;
         objId_ = objID;
     }
@@ -31,7 +32,12 @@ public:
     void setJointID(dJointID jointID);
 
     void addNail(NailDriver *nailDriver) {
+        nailCount++;
         maxFasteningForce += nailDriver->maxFasteningForce;
+    }
+
+    int getNailCount() {
+        return nailCount;
     }
 
     dBodyID getBodyID() { return objId_; }
@@ -40,6 +46,7 @@ public:
 
 private:
     double maxFasteningForce;
+    int nailCount;
     dBodyID objId_;
     dJointID jointID;
 };

--- a/src/ODEPlugin/ODESimulatorItem.cpp
+++ b/src/ODEPlugin/ODESimulatorItem.cpp
@@ -137,6 +137,11 @@ namespace cnoid {
 typedef std::map<dBodyID, Link*> CrawlerLinkMap;
 typedef std::map<dBodyID, VacuumGripper*> VacuumGripperMap;
 typedef std::map<dBodyID, NailDriver*> NailDriverMap;
+
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+typedef std::map<dBodyID, double> MecanumWheelSettingMap;
+#endif                      /* MECANUM_WHEEL_ODE */
+
 class ODESimulatorItemImpl
 {
 public:
@@ -152,6 +157,9 @@ public:
     VacuumGripperMap vacuumGripperDevs;
     NailDriverMap nailDriverDevs;
     //NailedObjectManager nailedObjectMngr;
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+    MecanumWheelSettingMap mecanumWheelSetting;
+#endif                      /* MECANUM_WHEEL_ODE */
     vector<ODELink*> geometryIdToLink;
 
     Selection stepMode;
@@ -187,6 +195,10 @@ public:
     void store(Archive& archive);
     void restore(const Archive& archive);
     void collisionCallback(const CollisionPair& collisionPair);
+
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+    void preserveMecanumWheelSetting(ODEBody* odeBody);
+#endif                      /* MECANUM_WHEEL_ODE */
 };
 }
 
@@ -1084,6 +1096,9 @@ void ODESimulatorItemImpl::clear()
     vacuumGripperDevs.clear();
     nailDriverDevs.clear();
     //nailedObjectMngr.clear();
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+    mecanumWheelSetting.clear();
+#endif                      /* MECANUM_WHEEL_ODE */
     geometryIdToLink.clear();
 }    
 
@@ -1153,6 +1168,10 @@ bool ODESimulatorItemImpl::initializeSimulation(const std::vector<SimulationBody
 	}
 #endif    /* Experimental. */
         addBody(static_cast<ODEBody*>(simBodies[i]));
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+        preserveMecanumWheelSetting(static_cast<ODEBody*>(simBodies[i]));
+#endif                      /* MECANUM_WHEEL_ODE */
+
 #if 1    /* Experimental. */
 	for (size_t i=0; i < odeBody->odeLinks.size(); ++i) {
 	    ODELinkPtr odeLink = odeBody->odeLinks[i];
@@ -1219,6 +1238,75 @@ cout << boost::format("ODESimulatorItemImpl::addBody: body.numJoints()=%d") % bo
     odeBody->createBody(this);
 }
 
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+/**
+   @brief Preserve mecanum wheel setting.
+   @param[in] odeBody Pointer of ODEBody.
+   @attention Please this method calling after addBody method.
+ */
+void ODESimulatorItemImpl::preserveMecanumWheelSetting(ODEBody* odeBody)
+{
+    Mapping* m;
+    Listing* links;
+    Listing* angles;
+
+    if (! odeBody) {
+        return;
+    }
+
+    m = odeBody->body()->info()->findMapping("mecanumWheelSetting");
+
+    if (! m->isValid()) {
+        return;
+    }
+
+    links  = m->findListing("links");
+    angles = m->findListing("barrelAngles");
+
+    if (! links->isValid() || links->size() < 1) {
+        return;
+    }
+
+    try {
+        for (size_t i = 0; i < links->size(); i++) {
+            string s = links->at(i)->toString();
+            double d = PI_2;
+            Link*  p = odeBody->body()->link(s);
+
+            if (angles->isValid() && angles->size() > i) {
+                d = angles->at(i)->toDouble();
+            }
+
+            if (! p) {
+                MessageView::instance()->putln(
+                    MessageView::ERROR,
+                    boost::format("link %1% not found in the %2%") % s % odeBody->body()->name()
+                    );
+                continue;
+            } else if (p->jointType() != Link::CRAWLER_JOINT) {
+                MessageView::instance()->putln(
+                    MessageView::ERROR,
+                    boost::format("link %1% is not crawler joint in the %2%") % s % odeBody->body()->name()
+                    );
+                continue;
+            }
+
+            for (size_t j = 0; j < odeBody->odeLinks.size(); j++) {
+                if (p == odeBody->odeLinks[j]->link) {
+                    mecanumWheelSetting.insert(make_pair(odeBody->odeLinks[j]->bodyID, d));
+                    break;
+                }
+            }
+        }
+    } catch (const ValueNode::NotScalarException ex) {
+        MessageView::instance()->putln(MessageView::ERROR, ex.message());
+    } catch(const ValueNode::ScalarTypeMismatchException ex) {
+        MessageView::instance()->putln(MessageView::ERROR, ex.message());
+    }
+
+    return;
+}
+#endif                      /* MECANUM_WHEEL_ODE */
 
 void ODESimulatorItem::initializeSimulationThread()
 {
@@ -1306,15 +1394,42 @@ static void nearCallback(void* data, dGeomID g1, dGeomID g2)
             dBodyID body2ID = dGeomGetBody(g2);
             Link* crawlerlink = 0;
             double sign = 1.0;
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+            bool isMecanumWheel = false;
+            double barrelAngle  = 0.0;
+#endif                      /* MECANUM_WHEEL_ODE */
             if(!impl->crawlerLinks.empty()){
                 CrawlerLinkMap::iterator p = impl->crawlerLinks.find(body1ID);
                 if(p != impl->crawlerLinks.end()){
                     crawlerlink = p->second;
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+                    {
+                        MecanumWheelSettingMap::iterator it = impl->mecanumWheelSetting.find(body1ID);
+
+                        if (it != impl->mecanumWheelSetting.end()) {
+                            isMecanumWheel = true;
+                            barrelAngle    = it->second;
+                        }
+                    }
+#endif                      /* MECANUM_WHEEL_ODE */
                 }
                 p = impl->crawlerLinks.find(body2ID);
                 if(p != impl->crawlerLinks.end()){
                     crawlerlink = p->second;
                     sign = -1.0;
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+                    {
+                        MecanumWheelSettingMap::iterator it = impl->mecanumWheelSetting.find(body2ID);
+
+                        if (it != impl->mecanumWheelSetting.end()) {
+                            isMecanumWheel = true;
+                            barrelAngle    = it->second;
+                        } else {
+                            isMecanumWheel = false;
+                            barrelAngle    = 0.0;
+                        }
+                    }
+#endif                      /* MECANUM_WHEEL_ODE */
                 }
             }
 #if 1    /* Experimental. */
@@ -1353,10 +1468,8 @@ cout << "*** vacuum gripper already gripping ***" << endl;
                                 dJointFeedback* fb = dJointGetFeedback(vacuumGripper->jointID);
 
                                 if (limitCheck(fb->f2, fb->t2, vacuumGripper)) {
-#ifdef VACUUM_GRIPPER_DEBUG
-MessageView::instance()->putln("VacuumGripper: *** joint destroy ***");
-cout << "VacuumGripper: *** joint destroy **" << endl;
-#endif // VACUUM_GRIPPER_DEBUG
+                                    MessageView::instance()->putln("VacuumGripper: *** joint destroy : exceeded the limit ***");
+                                    cout << "VacuumGripper: *** joint destroy : exceeded the limit  **" << endl;
                                     dJointSetFeedback(vacuumGripper->jointID, 0);
                                     dJointDestroy(vacuumGripper->jointID);
                                     vacuumGripper->jointID = 0;
@@ -1397,10 +1510,8 @@ cout << boost::format("VacuumGripper: *** other body jointed %s ***") % gripped 
                                 dJointSetFixed(jointID);
                                 dJointSetFeedback(jointID, new dJointFeedback());
                                 vacuumGripper->jointID = jointID;
-#ifdef VACUUM_GRIPPER_DEBUG
-MessageView::instance()->putln("VacuumGripper: *** joint created **");
-cout << "VacuumGripper: *** joint created **" << endl;
-#endif // VACUUM_GRIPPER_DEBUG
+                                MessageView::instance()->putln("VacuumGripper: *** joint created **");
+                                cout << "VacuumGripper: *** joint created **" << endl;
                             } else {
 #ifdef VACUUM_GRIPPER_DEBUG
 MessageView::instance()->putln("VacuumGripper: *** cannot create joint **");
@@ -1417,10 +1528,8 @@ cout << "VacuumGripper OFF **" << endl;
                             dJointSetFeedback(vacuumGripper->jointID, 0);
                             dJointDestroy(vacuumGripper->jointID);
                             vacuumGripper->jointID = 0;
-#ifdef VACUUM_GRIPPER_DEBUG
-MessageView::instance()->putln("VacuumGripper: *** joint destroy ***");
-cout << "VacuumGripper: *** joint destroy **" << endl;
-#endif // VACUUM_GRIPPER_DEBUG
+                            MessageView::instance()->putln("VacuumGripper: *** joint destroy : turned off ***");
+                            cout << "VacuumGripper: *** joint destroy : turned off **" << endl;
                         }
                     } // vacuumGripper->on()
                 } // vacuumGripper != 0
@@ -1452,49 +1561,60 @@ MessageView::instance()->putln(boost::format(_("NailDriver body2ID=%1%, Object b
                     }
                 }
                 if (nailDriver != 0) {
-		    if (nailDriver->on()) {
+                    if (nailDriver->on()) {
 #ifdef NAILDRIVER_DEBUG
 cout << "NailDriver ON **" << endl;
 #endif // NAILDRIVER_DEBUG
-			int n = nailDriver->checkContact(numContacts, contacts);
+                        int n = nailDriver->checkContact(numContacts, contacts);
 #ifdef NAILDRIVER_DEBUG
 MessageView::instance()->putln(boost::format(_("NailDriver: numContacts=%d n=%d")) % numContacts % n);
 cout << boost::format(_("NailDriver: numContacts=%d n=%d")) % numContacts % n << endl;
 #endif // NAILDRIVER_DEBUG
-			if (n) {
-				// TODO check object and other object
+                        if (n) {
+                                // TODO check object and other object
 #ifdef NAILDRIVER_DEBUG
 MessageView::instance()->putln(boost::format(_("NailDriver check body1ID=%1%")) % objId);
 #endif // NAILDRIVER_DEBUG
-				if (!nailedObjMngr->find(objId)) {
-				    NailedObject* nobj = new NailedObject(objId);
-				    // first
-				    dJointID jointID = dJointCreateFixed(impl->worldID, 0);
-				    dJointAttach(jointID, 0, objId);
-				    dJointSetFixed(jointID);
-				    dJointSetFeedback(jointID, new dJointFeedback());
-				    nobj->setJointID(jointID);
-				    nailedObjMngr->addObject(nobj);
-#ifdef VACUUM_GRIPPER_DEBUG
-MessageView::instance()->putln("NailDriver: *** joint created **");
-cout << "NailDriver: *** joint created **" << endl;
-#endif // VACUUM_GRIPPER_DEBUG
-				} else {
+                            NailedObjectPtr nobj = nailedObjMngr->get(objId);
+                            if (!nobj) {
+                                // first
+                                nobj = new NailedObject(objId);
+                                dJointID jointID = dJointCreateFixed(impl->worldID, 0);
+                                dJointAttach(jointID, 0, objId);
+                                dJointSetFixed(jointID);
+                                dJointSetFeedback(jointID, new dJointFeedback());
+                                nobj->setJointID(jointID);
+                                nobj->addNail(nailDriver);
+                                nailedObjMngr->addObject(nobj);
+                                MessageView::instance()->putln("NailDriver: *** joint created **");
+                                cout << "NailDriver: *** joint created **" << endl;
+#ifdef NAILDRIVER_DEBUG
+MessageView::instance()->putln(boost::format("NailDriver: nail count = %d") % nobj->getNailCount());
+cout << "NailDriver: nail count = " << nobj->getNailCount() << endl;
+#endif // NAILDRIVER_DEBUG
+                            } else {
 #ifdef NAILDRIVER_DEBUG
 MessageView::instance()->putln("NailDriver: *** joint already created **");
 cout << "NailDriver: *** joint already created **" << endl;
 #endif // NAILDRIVER_DEBUG
-                                    ;
-				    // second
-				    // TODO
-				}
-			} // n != 0
-		    } else {
+                                if (impl->self->currentTime() - nailDriver->getLatestContact() > 1.0 ) {
+                                    // second
+                                    nobj->addNail(nailDriver);
+#ifdef NAILDRIVER_DEBUG
+MessageView::instance()->putln(boost::format("NailDriver: nail count = %d") % nobj->getNailCount());
+cout << "NailDriver: nail count = " << nobj->getNailCount() << endl;
+#endif // NAILDRIVER_DEBUG
+                                }
+                            }
+                            const double current = impl->self->currentTime();
+                            nailDriver->setLatestContact(current);
+                        } // n != 0
+                    } else {
 #ifdef NAILDRIVER_DEBUG
 cout << "NailDriver OFF **" << endl;
 #endif // NAILDRIVER_DEBUG
                         ;
-		    }
+                    }
                 }
             }
 #endif    /* Experimental. */
@@ -1515,6 +1635,15 @@ cout << "NailDriver OFF **" << endl;
                     const Vector3 axis = crawlerlink->R() * crawlerlink->a();
                     const Vector3 n(contacts[i].geom.normal);
                     Vector3 dir = axis.cross(n);
+
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+                    if (isMecanumWheel) {
+                        Quaternion mwQ(AngleAxis(barrelAngle, n));
+                        Vector3    mwv = dir.cross(mwQ.vec());
+                        dir += mwv;
+                    }
+#endif                      /* MECANUM_WHEEL_ODE */
+
                     if(dir.norm() < 1.0e-5){
                         surface.mode = dContactApprox1;
                         surface.mu = impl->friction;

--- a/src/ODEPlugin/VacuumGripper.cpp
+++ b/src/ODEPlugin/VacuumGripper.cpp
@@ -122,7 +122,7 @@ Device* VacuumGripper::clone() const
  */
 VacuumGripper::VacuumGripper()
 {
-    on_ = true;
+    on_ = false;
     jointID = 0;
     position << 0, 0, 0;
     normalLine << 0, 0, 0;


### PR DESCRIPTION
ビス打ち機能について以下を実施しました。
- 同じ物体への2本め以降のビス打ち
  - ビス打ち器を物体から離さないと、次の射出を実行できないように修正した。
  - ビス打ち器と物体が接触したことは nearCallback で検知できるが、物体から離れたことは検知できない。そこで、NailDriver に nearCallback が実行された時刻 (SimulatorItem の currentTime()) を保存しておき、次の nearCallback で現在の currentTime() と比較して判定するようにした。
    
    現在は、両者の差が1.0より大きい場合は射出するように実装した (この値はYAMLプロパティで変更できるように改修する)。
  - ビス打ち器が物体に接触したままであっても、ビス打ち機能を一旦 OFF にすれば、ON に切り替えて射出できるように実装した。
  - ビスが打たれた方の物体で打たれた本数を計算するようにした。ただし以下の点を修正する必要がある
    - 異なるビス打ち器から打たれた場合、最大締結力が異なる場合がある。各ビス打ち器が何本射出したかを計算する。
    - 締結力の限界判定は実装できていない。

なお、メカナムホイール向けの実装も一部含まれています。こちらは作成中でまだ機能はしません。
