### PR TITLE
Snapshots at 0721a.

### DIFF
--- a/src/ODEPlugin/NailedObjectManager.h
+++ b/src/ODEPlugin/NailedObjectManager.h
@@ -31,10 +31,18 @@ public:
 
     void setJointID(dJointID jointID);
 
+    dJointID getJointID() { return jointID; }
+
     void addNail(NailDriver *nailDriver) {
         nailCount++;
         maxFasteningForce += nailDriver->maxFasteningForce;
     }
+
+    bool isLimited(double force) {
+        return force < maxFasteningForce;
+    }
+
+    const double getMaxFasteningForce() { return maxFasteningForce; }
 
     int getNailCount() {
         return nailCount;
@@ -72,6 +80,8 @@ public:
     NailedObjectPtr get(dBodyID bodyID);
 
     void clear();
+
+    NailedObjectMap& map() { return objectMap; }
 
 private:
     //std::map<dBodyID, NailedObjectPtr> objectMap;


### PR DESCRIPTION
＃ 昨日のPRをアップデートしようとしましたが、すでにマージしていただいたので新しいPRをたてます。

ビス打ち機能について以下を実施しました。
- 締結力判定処理を実装した。
  
  ODESimulatorItemImpl::nailedObjectLimitCheck() を実装した。
  
  この関数を SimulatorItam::addPostDynamicsFunction() で登録し、 ODESimulatorItem::stepSimulation() (nearCallback を実行する処理がある) の後で実行するようにした。
  
  ただし以下の問題があるため、判定後のジョイント削除処理は #if 0 - #endif で囲んで展開されないようにしている。
  - 限界値を越えた場合に固定ジョイントを削除するが、次の nearCallback で再度ビス打ちを実行してしまう。現在修正中。
