### PR TITLE
Snapshot at 0722a.

### DIFF
--- a/src/ODEPlugin/NailDriver.h
+++ b/src/ODEPlugin/NailDriver.h
@@ -5,6 +5,7 @@
 #ifndef CNOID_ODEPLUGIN_NAILDRIVER_H
 #define CNOID_ODEPLUGIN_NAILDRIVER_H
 
+#include "NailedObjectManager.h"
 #include <cnoid/EigenTypes>
 #include <cnoid/Body>
 #include <cnoid/Link>
@@ -40,12 +41,25 @@ public:
 
     int checkContact(int numContacts, dContact* contacts);
 
+    void contact() { near_callback_called = true; }
+
+    void distantCheck();
+
+    bool ready() const { return on_ && ready_; }
+    void setReady();
+
+    void fire(NailedObjectPtr nobj);
+
     void setLatestContact(const double current) { latestContact = current; }
     double getLatestContact() { return latestContact; }
     void resetLatestContact() { latestContact = 0.0; }
 
 private:
     bool on_;
+    bool contact_;
+    bool ready_;
+    int not_called_conunt;
+    bool near_callback_called;
 
 public:
     Vector3 position;

--- a/src/ODEPlugin/NailedObjectManager.cpp
+++ b/src/ODEPlugin/NailedObjectManager.cpp
@@ -23,7 +23,10 @@ using namespace std;
 
 NailedObject::~NailedObject()
 {
-    ;
+    MessageView::instance()->putln("NailDriver: *** joint destroy ***");
+    cout << "NailDriver: *** joint destroy  **" << endl;
+    dJointSetFeedback(jointID, 0);
+    dJointDestroy(jointID);
 }
 
 NailedObjectManager* NailedObjectManager::getInstance()
@@ -73,5 +76,3 @@ NailedObjectPtr NailedObjectManager::get(dBodyID bodyID)
 
     return 0;
 }
-
-

--- a/src/ODEPlugin/NailedObjectManager.h
+++ b/src/ODEPlugin/NailedObjectManager.h
@@ -5,8 +5,6 @@
 #ifndef CNOID_ODEPLUGIN_NAILEDOBJECTMANAGER_H
 #define CNOID_ODEPLUGIN_NAILEDOBJECTMANAGER_H
 
-#include <cnoid/NailDriver>
-
 #include <cnoid/Referenced>
 #include <cnoid/EigenTypes>
 #include <cnoid/Body>
@@ -34,10 +32,16 @@ public:
     }
     ~NailedObject();
 
-    void addNail(NailDriver *nailDriver) {
+    void addNail(double fasteningForce) {
         nailCount++;
-        maxFasteningForce += nailDriver->maxFasteningForce;
+        maxFasteningForce += fasteningForce;
     }
+
+    bool isLimited(double force) {
+        return force < maxFasteningForce;
+    }
+
+    const double getMaxFasteningForce() { return maxFasteningForce; }
 
     int getNailCount() {
         return nailCount;
@@ -75,6 +79,8 @@ public:
     NailedObjectPtr get(dBodyID bodyID);
 
     void clear();
+
+    NailedObjectMap& map() { return objectMap; }
 
 private:
     //std::map<dBodyID, NailedObjectPtr> objectMap;


### PR DESCRIPTION
＃ masterブランチが更新されているので古いPRはcloseして新たにPRします。

ビス打ち機能について以下を実施しました。
- ビス打ち器が物体から離れたかどうかの判定方法を変更した。
  - ビス打ち器を引数にとる nearCallback の呼び出しが行われなくなったら物体から離れたとみなすように修正した。
  - ただし、見た目には離れていなくても、数ステップだけ nearCallback が呼ばれなくなる場合があるようなので nearCallback を呼ばない処理が5回以上続く場合に離れたと判定するようにした。
