### PR TITLE
Snapshot at 0724a.

### DIFF
--- a/src/ODEPlugin/NailDriver.cpp
+++ b/src/ODEPlugin/NailDriver.cpp
@@ -4,6 +4,7 @@
 */
 
 #include <cnoid/NailDriver>
+#include "NailedObjectManager.h"
 
 #include <cnoid/Device>
 #include <cnoid/EigenUtil>
@@ -53,6 +54,7 @@ NailDriver::NailDriver()
 
     not_called_conunt = 0;
     near_callback_called = false;
+    distantCheckCount = 20;
 
     resetLatestContact();
 }
@@ -77,6 +79,7 @@ NailDriver::NailDriver(const NailDriver& org, bool copyStateOnly)
     position = org.position;
     normal = org.normal;
     maxFasteningForce = org.maxFasteningForce;
+    distantCheckCount = org.distantCheckCount;
 }
 
 
@@ -115,7 +118,7 @@ void NailDriver::setReady()
     ready_ = true;
 }
 
-void NailDriver::fire(NailedObjectPtr nobj)
+void NailDriver::fire(NailedObject* nobj)
 {
 
     MessageView::instance()->putln(boost::format(_("%s: Fire")) % typeName());
@@ -129,8 +132,9 @@ void NailDriver::distantCheck()
 {
     if (!near_callback_called) {
         // Check number of times nearCallback() was not called continuously.
-        // If more than 5 times, it is processing as a distant from object.
-        if (not_called_conunt < 5) {
+        // If more than distantCheckCount times, it is processing as a
+        // distant from object.
+        if (not_called_conunt < distantCheckCount) {
             not_called_conunt++;
         } else {
             if (on() && !ready()) {

--- a/src/ODEPlugin/NailDriver.cpp
+++ b/src/ODEPlugin/NailDriver.cpp
@@ -122,6 +122,11 @@ void NailDriver::fire(NailedObject* nobj)
     MessageView::instance()->putln(boost::format(_("%s: Fire")) % typeName());
     cout << boost::format(_("%s: Fire")) % typeName() << endl;
 
+    if (nobj->getNailCount() == 0) {
+        const Vector3 n = link()->R() * normal;
+        nobj->setNailDirection(n);
+    }
+
     nobj->addNail(maxFasteningForce);
     ready_ = false;
 }

--- a/src/ODEPlugin/NailDriver.cpp
+++ b/src/ODEPlugin/NailDriver.cpp
@@ -54,7 +54,6 @@ NailDriver::NailDriver()
 
     not_called_conunt = 0;
     near_callback_called = false;
-    distantCheckCount = 20;
 
     resetLatestContact();
 }
@@ -79,7 +78,6 @@ NailDriver::NailDriver(const NailDriver& org, bool copyStateOnly)
     position = org.position;
     normal = org.normal;
     maxFasteningForce = org.maxFasteningForce;
-    distantCheckCount = org.distantCheckCount;
 }
 
 
@@ -128,7 +126,7 @@ void NailDriver::fire(NailedObject* nobj)
     ready_ = false;
 }
 
-void NailDriver::distantCheck()
+void NailDriver::distantCheck(int distantCheckCount)
 {
     if (!near_callback_called) {
         // Check number of times nearCallback() was not called continuously.

--- a/src/ODEPlugin/NailDriver.h
+++ b/src/ODEPlugin/NailDriver.h
@@ -5,7 +5,6 @@
 #ifndef CNOID_ODEPLUGIN_NAILDRIVER_H
 #define CNOID_ODEPLUGIN_NAILDRIVER_H
 
-#include "NailedObjectManager.h"
 #include <cnoid/EigenTypes>
 #include <cnoid/Body>
 #include <cnoid/Link>
@@ -15,6 +14,7 @@
 #include <ode/ode.h>
 
 namespace cnoid {
+class NailedObject;
 
 class CNOID_EXPORT NailDriver : public Device
 {
@@ -48,7 +48,7 @@ public:
     bool ready() const { return on_ && ready_; }
     void setReady();
 
-    void fire(NailedObjectPtr nobj);
+    void fire(NailedObject* nobj);
 
     void setLatestContact(const double current) { latestContact = current; }
     double getLatestContact() { return latestContact; }
@@ -65,6 +65,7 @@ public:
     Vector3 position;
     Vector3 normal;
     double maxFasteningForce;
+    int distantCheckCount;
     double latestContact;
 };
 

--- a/src/ODEPlugin/NailDriver.h
+++ b/src/ODEPlugin/NailDriver.h
@@ -43,7 +43,7 @@ public:
 
     void contact() { near_callback_called = true; }
 
-    void distantCheck();
+    void distantCheck(int distantCheckCount);
 
     bool ready() const { return on_ && ready_; }
     void setReady();
@@ -65,7 +65,6 @@ public:
     Vector3 position;
     Vector3 normal;
     double maxFasteningForce;
-    int distantCheckCount;
     double latestContact;
 };
 

--- a/src/ODEPlugin/NailedObjectManager.cpp
+++ b/src/ODEPlugin/NailedObjectManager.cpp
@@ -29,6 +29,23 @@ NailedObject::~NailedObject()
     dJointDestroy(jointID);
 }
 
+bool NailedObject::isLimited()
+{
+    dJointFeedback* fb = dJointGetFeedback(jointID);
+
+    Vector3 f(fb->f1);
+    double fasteningForce = n_.dot(f);
+
+    // check fastening force
+    if (fasteningForce > maxFasteningForce) {
+        MessageView::instance()->putln(boost::format("FasteningForce limit exceeded: %f > %f") % fasteningForce % maxFasteningForce);
+        cout << boost::format("FasteningForce limit exceeded: %f > %f") % fasteningForce % maxFasteningForce << endl;
+        return true;
+    }
+    return false;
+}
+
+
 NailedObjectManager* NailedObjectManager::getInstance()
 {
     static NailedObjectManager instance;

--- a/src/ODEPlugin/NailedObjectManager.h
+++ b/src/ODEPlugin/NailedObjectManager.h
@@ -38,7 +38,7 @@ public:
     }
 
     bool isLimited(double force) {
-        return force < maxFasteningForce;
+        return force + maxFasteningForce < 0;
     }
 
     const double getMaxFasteningForce() { return maxFasteningForce; }

--- a/src/ODEPlugin/NailedObjectManager.h
+++ b/src/ODEPlugin/NailedObjectManager.h
@@ -37,15 +37,15 @@ public:
         maxFasteningForce += fasteningForce;
     }
 
-    bool isLimited(double force) {
-        return force + maxFasteningForce < 0;
-    }
+    bool isLimited();
 
     const double getMaxFasteningForce() { return maxFasteningForce; }
 
     int getNailCount() {
         return nailCount;
     }
+
+    void setNailDirection(const Vector3 n) { n_ = n; }
 
     dBodyID getBodyID() { return objId_; }
 
@@ -56,6 +56,7 @@ private:
     int nailCount;
     dBodyID objId_;
     dJointID jointID;
+    Vector3 n_;
 };
 
 typedef ref_ptr<NailedObject> NailedObjectPtr;

--- a/src/ODEPlugin/ODESimulatorItem.cpp
+++ b/src/ODEPlugin/ODESimulatorItem.cpp
@@ -187,6 +187,7 @@ public:
 
     double vacuumGripperLimitCheckStartTime;
     double nailDriverLimitCheckStartTime;
+    int nailDriverDistantCheckCount;
 
     ODESimulatorItemImpl(ODESimulatorItem* self);
     ODESimulatorItemImpl(ODESimulatorItem* self, const ODESimulatorItemImpl& org);
@@ -1094,6 +1095,11 @@ void ODESimulatorItem::setNailDriverLimitCheckStartTime(double limitCheckStartTi
     impl->nailDriverLimitCheckStartTime = limitCheckStartTime;
 }
 
+void ODESimulatorItem::setNailDriverDistantCheckCount(int distantCheckCount)
+{
+    impl->nailDriverDistantCheckCount = distantCheckCount;
+}
+
 void ODESimulatorItem::setAllLinkPositionOutputMode(bool on)
 {
     // The mode is not changed.
@@ -1856,7 +1862,7 @@ void ODESimulatorItemImpl::nailDriverCheck()
     for (NailDriverMap::iterator p = nailDriverDevs.begin();
          p != nailDriverDevs.end(); p++) {
         NailDriver* nailDriver = p->second;
-        nailDriver->distantCheck();
+        nailDriver->distantCheck(nailDriverDistantCheckCount);
     }
 }
 

--- a/src/ODEPlugin/ODESimulatorItem.cpp
+++ b/src/ODEPlugin/ODESimulatorItem.cpp
@@ -36,6 +36,10 @@
 #include <cnoid/MessageView>
 #include <boost/format.hpp>
 
+#ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
+#define MECANUM_WHEEL_ODE_DEBUG 0
+#endif                      /* MECANUM_WHEEL_ODE */
+
 using namespace std;
 using namespace boost;
 using namespace cnoid;
@@ -159,8 +163,9 @@ public:
     //NailedObjectManager nailedObjectMngr;
 #ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
     MecanumWheelSettingMap mecanumWheelSetting;
-    // XXX: this variable will erase later.
+#if (MECANUM_WHEEL_ODE_DEBUG > 0)    /* MECANUM_WHEEL_ODE_DEBUG */
     bool                   mecanumWheelDebug;
+#endif                               /* MECANUM_WHEEL_ODE_DEBUG */
 #endif                      /* MECANUM_WHEEL_ODE */
     vector<ODELink*> geometryIdToLink;
 
@@ -546,9 +551,9 @@ void ODELink::setKinematicStateToODE()
                 offset = it0->second;
             Position T_ = T*offset;
             Vector3 p = T_.translation() + link->c();
-            dMatrix3 R2 = { T(0,0), T(0,1), T(0,2), 0.0,
-                            T(1,0), T(1,1), T(1,2), 0.0,
-                            T(2,0), T(2,1), T(2,2), 0.0 };
+            dMatrix3 R2 = { T_(0,0), T_(0,1), T_(0,2), 0.0,
+                            T_(1,0), T_(1,1), T_(1,2), 0.0,
+                            T_(2,0), T_(2,1), T_(2,2), 0.0 };
 
             dGeomSetPosition(*it, p.x(), p.y(), p.z());
             dGeomSetRotation(*it, R2);
@@ -929,8 +934,9 @@ ODESimulatorItemImpl::ODESimulatorItemImpl(ODESimulatorItem* self)
     velocityMode = false;
 
 #ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
-    // XXX: this code will erase later.
+#if (MECANUM_WHEEL_ODE_DEBUG > 0)    /* MECANUM_WHEEL_ODE_DEBUG */
     mecanumWheelDebug = false;
+#endif                               /* MECANUM_WHEEL_ODE_DEBUG */
 #endif                      /* MECANUM_WHEEL_ODE */
 }
 
@@ -1262,7 +1268,7 @@ MessageView::instance()->putln(boost::format("Add NailDriver: bodyID=%d target=%
 /**
    @brief Preserve mecanum wheel setting.
    @param[in] odeBody Pointer of ODEBody.
-   @attention Please this method calling after addBody method.
+   @attention Please this method calling from addBody method.
  */
 void ODESimulatorItemImpl::preserveMecanumWheelSetting(ODEBody* odeBody)
 {
@@ -1290,7 +1296,7 @@ void ODESimulatorItemImpl::preserveMecanumWheelSetting(ODEBody* odeBody)
     for (size_t i = 0; i < links->size(); i++) {
         try {
             string s = links->at(i)->toString();
-            double d = PI_2;
+            double d = 0.0;
             Link*  p = odeBody->body()->link(s);
 
             if (! p) {
@@ -1308,12 +1314,31 @@ void ODESimulatorItemImpl::preserveMecanumWheelSetting(ODEBody* odeBody)
             }
 
             if (angles->isValid() && angles->size() > i) {
-                d = angles->at(i)->toDouble();
+                double d2;
+
+                d2 = angles->at(i)->toDouble();
+
+                if (d2 != 0.0) {
+                    d = (abs(PI_2 - d2) < 0.00001) ? 0.0 : d2;
+                } else {
+                    d = PI_2;
+                }
             }
 
             for (size_t j = 0; j < odeBody->odeLinks.size(); j++) {
                 if (p == odeBody->odeLinks[j]->link) {
                     mecanumWheelSetting.insert(make_pair(odeBody->odeLinks[j]->bodyID, d));
+#if (MECANUM_WHEEL_ODE_DEBUG > 0)    /* MECANUM_WHEEL_ODE_DEBUG */
+
+                    if (mecanumWheelDebug) {
+                        MessageView::instance()->putln(
+                            MessageView::NORMAL,
+                            boost::format("%1%: mecanum wheel %2% (%3% radians)")
+                                % __PRETTY_FUNCTION__ % p->name() % d
+                            );
+                    }
+
+#endif                               /* MECANUM_WHEEL_ODE_DEBUG */
                     break;
                 }
             }
@@ -1544,15 +1569,15 @@ cout << "NailDriver OFF **" << endl;
 #ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
                     if (isMecanumWheel) {
                         Vector3 mwdir = AngleAxis(barrelAngle, n).toRotationMatrix().transpose() * dir;
+#if (MECANUM_WHEEL_ODE_DEBUG > 0)    /* MECANUM_WHEEL_ODE_DEBUG */
 
-                        // XXX: this block will erase later.
                         if (impl->mecanumWheelDebug) {
                             cout << crawlerlink->name() << endl;
-                            cout << "dir  : " << dir.transpose() << endl;
-                            cout << "mwdir: " << mwdir.transpose() << endl;
-                            cout << "-----" << endl;
+                            cout << "\tcrawler's dir      : " << dir.transpose() << endl;
+                            cout << "\tmecanum wheel's dir: " << mwdir.transpose() << endl;
                         }
 
+#endif                               /* MECANUM_WHEEL_ODE_DEBUG */
                         dir = mwdir;
                     }
 #endif                      /* MECANUM_WHEEL_ODE */
@@ -1662,11 +1687,8 @@ void ODESimulatorItemImpl::collisionCallback(const CollisionPair& collisionPair)
     ODELink* link2 = geometryIdToLink[collisionPair.geometryId[1]];
     const vector<Collision>& collisions = collisionPair.collisions;
 
-cout << "ODESimulatorItemImpl:collisionCallback ***" << endl;
     dBodyID body1ID = link1->bodyID;
     dBodyID body2ID = link2->bodyID;
-cout << "ODESimulatorItemImpl:collisionCallback: body1ID:" << body1ID << endl;
-cout << "ODESimulatorItemImpl:collisionCallback: body2ID:" << body2ID << endl;
     Link* crawlerlink = 0;
     double sign = 1.0;
     if(!crawlerLinks.empty()){
@@ -1775,8 +1797,9 @@ void ODESimulatorItemImpl::doPutProperties(PutPropertyFunction& putProperty)
     putProperty(_("Velocity Control Mode"), velocityMode, changeProperty(velocityMode));
 
 #ifdef MECANUM_WHEEL_ODE    /* MECANUM_WHEEL_ODE */
-    // XXX: this code will erase later.
+#if (MECANUM_WHEEL_ODE_DEBUG > 0)    /* MECANUM_WHEEL_ODE_DEBUG */
     putProperty("Mecanum Wheel Debug Mode", mecanumWheelDebug, changeProperty(mecanumWheelDebug));
+#endif                               /* MECANUM_WHEEL_ODE_DEBUG */
 #endif                      /* MECANUM_WHEEL_ODE */
 }
 
@@ -1881,23 +1904,12 @@ void ODESimulatorItemImpl::nailedObjectLimitCheck()
 
     NailedObjectMap::iterator p = map.begin();
     while (p != map.end()) {
-        dBodyID id = p->first;
         NailedObjectPtr nobj = p->second;
-        const dReal* pos = dBodyGetPosition(id);
 
-        Vector3 f(nobj->fb.f1);
-        Vector3 tau(nobj->fb.t1);
-
-#if 0 /* Experimental. */
-        if (nobj->isLimited(f[0])) {
-            MessageView::instance()->putln("NailDriver: *** exceeded the limit ***");
-            cout << "NailDriver: *** exceeded the limit  **" << endl;
+        if (nobj->isLimited()) {
             map.erase(p++);
         } else {
             p++;
         }
-#else /* Experimental. */
-        p++;
-#endif /* Experimental. */
     }
 }

--- a/src/ODEPlugin/ODESimulatorItem.h
+++ b/src/ODEPlugin/ODESimulatorItem.h
@@ -46,9 +46,11 @@ public:
 
     // for VacuumGripper simulation
     void useVacuumGripper(bool on);
+    void setVacuumGripperLimitCheckStartTime(double limitCheckStartTime);
 
     // for NailDriver simulation
     void useNailDriver(bool on);
+    void setNailDriverLimitCheckStartTime(double limitCheckStartTime);
 
 protected:
         

--- a/src/ODEPlugin/ODESimulatorItem.h
+++ b/src/ODEPlugin/ODESimulatorItem.h
@@ -51,6 +51,7 @@ public:
     // for NailDriver simulation
     void useNailDriver(bool on);
     void setNailDriverLimitCheckStartTime(double limitCheckStartTime);
+    void setNailDriverDistantCheckCount(int distantCheckCount);
 
 protected:
         


### PR DESCRIPTION
以下を実施しました。
- 吸着機能
  - VacuumGripperSimulatorItem に limitCheckStartTime プロパティを追加した。
    
    シミュレーション開始からしばらくの間、dJointFeedback に設定される値が大きすぎるようなので、限界判定の開始を遅らせることができるようにした。
    
    デフォルトでは、開始から 0.3 秒までは限界判定を行わない。0.3秒という値は実験により求めた。
- ビス打ち機能
  - NailDriverSimulatorItem に limitCheckStartTime プロパティを追加した。
    
    吸着機能と同様の理由により追加した。
    デフォルトでは、開始から 0.3 秒までは限界判定を行わない。
  - 締結力判定処理を修正した。
    
    ビス方向の力で判定するように修正したつもりですが、もし考え方に間違いがありましたら改めて計算方法(式)を教えてください。
  - ビス打ち器が物体から離れたかどうかの判定の修正
    - nearCallback を呼ばない処理が続く回数のしきい値を設定するため、YAMLファイルに distantCheckCount を記述できるようにした。
    - 機器ごとの設定ではなく NailDriverSimulatorItem の方がよいかもしれませんが、その場合は修正します。
