### PR TITLE
refactoring the extend feature

### DIFF
--- a/src/ODEPlugin/NailDriver.cpp
+++ b/src/ODEPlugin/NailDriver.cpp
@@ -94,9 +94,13 @@ double* NailDriver::writeState(double* out_buf) const
 }
 
 void NailDriver::on(bool on) {
-    string msg = str(boost::format(_("%s: %s %s => %s")) % typeName() % link()->name() % (on_ ? "ON" : "OFF") % (on ? "ON" : "OFF"));
+    string msg = str(
+        boost::format(_("%s: %s %s => %s")) % typeName() % link()->name() % (on_ ? "ON" : "OFF") % (on ? "ON" : "OFF")
+        );
     MessageView::instance()->putln(msg);
+#ifdef NAILDRIVER_DEBUG    /* NAILDRIVER_DEBUG */
     cout << msg << endl;
+#endif                     /* NAILDRIVER_DEBUG */
 
     if (on_ == false && on == true) {
         // By switching from off to on,
@@ -111,7 +115,9 @@ void NailDriver::setReady()
 {
     string msg = str(boost::format(_("%s: %s Ready")) % typeName() % link()->name());
     MessageView::instance()->putln(msg);
+#ifdef NAILDRIVER_DEBUG    /* NAILDRIVER_DEBUG */
     cout << msg << endl;
+#endif                     /* NAILDRIVER_DEBUG */
 
     ready_ = true;
 }
@@ -121,7 +127,9 @@ void NailDriver::fire(NailedObject* nobj)
     string msg;
     msg = str(boost::format(_("%s: %s Fire")) % typeName() % link()->name());
     MessageView::instance()->putln(msg);
+#ifdef NAILDRIVER_DEBUG    /* NAILDRIVER_DEBUG */
     cout << msg << endl;
+#endif                     /* NAILDRIVER_DEBUG */
 
     if (nobj->getNailCount() == 0) {
 #ifdef NAILDRIVER_STATUS

--- a/src/ODEPlugin/ODESimulatorItem.h
+++ b/src/ODEPlugin/ODESimulatorItem.h
@@ -52,12 +52,6 @@ public:
     void useVacuumGripper(bool on);
 
     /**
-       @brief Set vacuum gripper limit check start time.
-       @param[in] limitCheckStartTime To set the time until the start of limit check of the restraint forces.
-     */
-    void setVacuumGripperLimitCheckStartTime(double limitCheckStartTime);
-
-    /**
        @brief Set vacuum gripper dot product threshold.
        @param[in] threshold If the dot product of the grip surface and the object is less than this value,
        then gripping the object.

--- a/src/ODEPlugin/VacuumGripper.cpp
+++ b/src/ODEPlugin/VacuumGripper.cpp
@@ -90,9 +90,13 @@ double* VacuumGripper::writeState(double* out_buf) const
 }
 
 void VacuumGripper::on(bool on) {
-    string msg = str(boost::format(_("%s: %s %s => %s")) % typeName() % link()->name() % (on_ ? "ON" : "OFF") % (on ? "ON" : "OFF"));
+    string msg = str(
+        boost::format(_("%s: %s %s => %s")) % typeName() % link()->name() % (on_ ? "ON" : "OFF") % (on ? "ON" : "OFF")
+        );
     MessageView::instance()->putln(msg);
+#ifdef VACUUM_GRIPPER_DEBUG    /* VACUUM_GRIPPER_DEBUG */
     cout << msg << endl;
+#endif                         /* VACUUM_GRIPPER_DEBUG */
     on_ = on;
 }
 
@@ -181,21 +185,27 @@ bool VacuumGripper::limitCheck(double currentTime)
     if (pullForce + (dReal)maxPullForce < 0) {
         string msg = str(boost::format("PullForce limit exceeded: %f > %f") % fabs(pullForce) % maxPullForce);
         MessageView::instance()->putln(msg);
+#ifdef VACUUM_GRIPPER_DEBUG    /* VACUUM_GRIPPER_DEBUG */
         cout << msg << endl;
+#endif                         /* VACUUM_GRIPPER_DEBUG */
         return true;
     }
 
     if (shearForce > (dReal)maxShearForce) {
         string msg = str(boost::format("ShearForce limit exceeded: %f > %f") % shearForce % maxShearForce);
         MessageView::instance()->putln(msg);
+#ifdef VACUUM_GRIPPER_DEBUG    /* VACUUM_GRIPPER_DEBUG */
         cout << msg << endl;
+#endif                         /* VACUUM_GRIPPER_DEBUG */
         return true;
     }
 
     if (peelTorque > (dReal)maxPeelTorque) {
         string msg = str(boost::format("PeelTorque limit exceeded: %f > %f") % peelTorque % maxPeelTorque);
         MessageView::instance()->putln(msg);
+#ifdef VACUUM_GRIPPER_DEBUG    /* VACUUM_GRIPPER_DEBUG */
         cout << msg << endl;
+#endif                         /* VACUUM_GRIPPER_DEBUG */
         return true;
     }
 


### PR DESCRIPTION
吸着ハンド、ビス撃ち機、メカナムホイール機能のリファクタリングを実施しました。
- nearCallback 内に直書きしていたコードを ODESimulatorImpl クラス vacuumGripperNearCallback, nailDriverNearCallback, getMecanumWheelSetting メソッドとし、これらを nearCallback から呼び出すようにしました。
- 前項の対応時に ODESimulatorImpl クラス checkContact メソッドを廃止し vacuumGripperNearCallback, nailDriverNearCallback 内で同様の処理を実施するようにしました。
- 動作試験で現象 (シミュレーション開始に大きな力が掛かる) が再現しなかった limit check start time プロパティおよび、関連する処理を削除しました。
- 標準出力へのメッセージ出力を抑制しました。
